### PR TITLE
Change the default code sign identity to "iPhone Developer"

### DIFF
--- a/Result.xcodeproj/project.pbxproj
+++ b/Result.xcodeproj/project.pbxproj
@@ -591,6 +591,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -611,6 +612,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;


### PR DESCRIPTION
This patch changes the default code signing identity to the wildcard "iPhone Developer" settings.

Previously this was not set, which means that automated builds, like for example on Xcode Server or Travis-CI, cannot work without manually patching this. The deeper problem behind this is that Xcode 6.1.1 will not build dependend frameworks without those being signed as part of the build:

> `CodeSign error: code signing is required for product type 'Framework' in SDK 'iOS 8.2'`

Note that the *Deferred* project already has the default signing identity set and builds fine on automated builds.